### PR TITLE
Updated To Support Passwords For Auto-Renewal Subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ else
   puts "Receipt is not valid"
 end
 
+# Optional 3rd parameter if validating Auto-Renewal Subscriptions
+if IAPValidator::IAPValidator.valid?(receipt_data, true, "shared_secret_string")
+  puts "Receipt is valid"
+else
+  puts "Receipt is not valid"
+end
+
 # You can also get more information about the receipt
 resp = IAPValidator::IAPValidator.validate(receipt_data, true)
 puts resp["status"]

--- a/README.md
+++ b/README.md
@@ -34,11 +34,7 @@ else
 end
 
 # Optional 3rd parameter if validating Auto-Renewal Subscriptions
-if IAPValidator::IAPValidator.valid?(receipt_data, true, "shared_secret_string")
-  puts "Receipt is valid"
-else
-  puts "Receipt is not valid"
-end
+valid = IAPValidator::IAPValidator.valid?(receipt_data, true, "shared_secret_string")
 
 # You can also get more information about the receipt
 resp = IAPValidator::IAPValidator.validate(receipt_data, true)

--- a/lib/iap-validator.rb
+++ b/lib/iap-validator.rb
@@ -17,7 +17,7 @@ module IAPValidator
     def self.validate(data, sandbox = false, password = nil)
       base_uri SANDBOX_URL if sandbox
 
-      json = password.nil? 
+      json = password.nil? ? 
         { 'receipt-data' => data } : 
         { 'receipt-data' => data, 'password' => password }
 

--- a/lib/iap-validator.rb
+++ b/lib/iap-validator.rb
@@ -14,10 +14,14 @@ module IAPValidator
     headers 'Content-Type' => 'application/json'
     format :json
 
-    def self.validate(data, sandbox = false)
+    def self.validate(data, sandbox = false, password = nil)
       base_uri SANDBOX_URL if sandbox
 
-      resp = post('/verifyReceipt', :body => MultiJson.encode({ 'receipt-data' => data }) )
+      json = password.nil? 
+        { 'receipt-data' => data } : 
+        { 'receipt-data' => data, 'password' => password }
+
+      resp = post('/verifyReceipt', :body => MultiJson.encode(json) )
 
       if resp.code == 200
         MultiJson.decode(resp.body())


### PR DESCRIPTION
I have updated the code to support an optional 3rd parameter which is the shared secret that must be used when validating receipts for auto-renewal subscriptions.  I have also updated the README to show how to use this parameter.

Thanks for the great gem!
