### PR TITLE
Replace HTTParty with Typhoeus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ pkg
 
 # For rubinius:
 #*.rbc
+
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-iap-validator can be used to validate base64 encoded iTunes in app purchase receipts.
+iap-validator v2.0.0 can be used to validate base64 encoded iTunes in app purchase receipts.
 
 ## Getting started
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end

--- a/iap-validator.gemspec
+++ b/iap-validator.gemspec
@@ -20,4 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "httparty"
+  s.add_dependency "multi_json"
+
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'webmock'
 end

--- a/iap-validator.gemspec
+++ b/iap-validator.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "httparty"
+  s.add_dependency "typhoeus"
   s.add_dependency "multi_json"
 
   s.add_development_dependency 'rspec'

--- a/lib/iap-validator.rb
+++ b/lib/iap-validator.rb
@@ -15,7 +15,7 @@ module IAPValidator
     headers 'Content-Type' => 'application/json'
     format :json
 
-    def self.validate(data, sandbox = false, password = nil, &on_error)
+    def self.validate(data, sandbox = false, password = nil)
       base_uri SANDBOX_URL if sandbox
 
       json = password.nil? ?
@@ -27,7 +27,6 @@ module IAPValidator
       if resp.code == 200
         MultiJson.decode(resp.body())
       else
-        on_error.call(resp) if block_given?
         nil
       end
     end

--- a/lib/iap-validator.rb
+++ b/lib/iap-validator.rb
@@ -1,6 +1,7 @@
 require "iap-validator/version"
 
 require 'httparty'
+require 'multi_json'
 
 module IAPValidator
   class IAPValidator

--- a/lib/iap-validator.rb
+++ b/lib/iap-validator.rb
@@ -14,10 +14,14 @@ module IAPValidator
     headers 'Content-Type' => 'application/json'
     format :json
 
-    def self.validate(data, sandbox = false)
+    def self.validate(data, sandbox = false, password = nil)
       base_uri SANDBOX_URL if sandbox
 
-      resp = post('/verifyReceipt', :body => MultiJson.encode({ 'receipt-data' => data }) )
+      json = password.nil? ?
+        { 'receipt-data' => data } :
+        { 'receipt-data' => data, 'password' => password }
+
+      resp = post('/verifyReceipt', :body => MultiJson.encode(json))
 
       if resp.code == 200
         MultiJson.decode(resp.body())

--- a/lib/iap-validator.rb
+++ b/lib/iap-validator.rb
@@ -14,7 +14,7 @@ module IAPValidator
     headers 'Content-Type' => 'application/json'
     format :json
 
-    def self.validate(data, sandbox = false, password = nil)
+    def self.validate(data, sandbox = false, password = nil, &on_error)
       base_uri SANDBOX_URL if sandbox
 
       json = password.nil? ?
@@ -26,6 +26,7 @@ module IAPValidator
       if resp.code == 200
         MultiJson.decode(resp.body())
       else
+        on_error.call(resp) if block_given?
         nil
       end
     end

--- a/lib/iap-validator/version.rb
+++ b/lib/iap-validator/version.rb
@@ -1,3 +1,3 @@
 module IAPValidator
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -7,12 +7,9 @@ rescue Bundler::BundlerError => e
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
 end
-require 'test/unit'
-require 'shoulda'
+require 'rspec'
+require 'webmock/rspec'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'iap-validator'
-
-class Test::Unit::TestCase
-end

--- a/spec/iap-validator_spec.rb
+++ b/spec/iap-validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe IAPValidator::IAPValidator do
     expect(resp).to eq(expected_response)
   end
 
-  it 'should validate with error callback' do
+  it 'should validate with error' do
     receipt_data = 'randomreceiptdata'
     expected_response = { "cool" => 123 }
     expected_response_str = MultiJson.dump(expected_response)
@@ -26,33 +26,10 @@ RSpec.describe IAPValidator::IAPValidator do
         with(body: { 'receipt-data' => receipt_data }).
         and_return(status: 400, body: expected_response_str)
 
-    error = nil
-    resp = IAPValidator::IAPValidator.validate(receipt_data, true) do |error_resp|
-      error = error_resp
-    end
-
-    expect(stub).to have_been_requested
-    expect(resp).to be_nil
-    expect(error).to_not be_nil
-    expect(error.code).to eq(400)
-    expect(error.body).to eq(expected_response_str)
-  end
-
-  it 'should validate without error callback' do
-    receipt_data = 'randomreceiptdata'
-    expected_response = { "cool" => 123 }
-    expected_response_str = MultiJson.dump(expected_response)
-
-    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
-        with(body: { 'receipt-data' => receipt_data }).
-        and_return(status: 400, body: expected_response_str)
-
-    error = nil
     resp = IAPValidator::IAPValidator.validate(receipt_data, true)
 
     expect(stub).to have_been_requested
     expect(resp).to be_nil
-    expect(error).to be_nil
   end
 
 end

--- a/spec/iap-validator_spec.rb
+++ b/spec/iap-validator_spec.rb
@@ -1,15 +1,14 @@
 require 'helper'
 
 RSpec.describe IAPValidator::IAPValidator do
-
   it 'should validate' do
     receipt_data = 'randomreceiptdata'
-    expected_response = { "cool" => 123 }
+    expected_response = { 'cool' => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
-        with(body: { 'receipt-data' => receipt_data }).
-        and_return(status: 200, body: expected_response_str)
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt')
+           .with(body: { 'receipt-data' => receipt_data })
+           .and_return(status: 200, body: expected_response_str)
 
     resp = IAPValidator::IAPValidator.validate(receipt_data, true)
 
@@ -19,17 +18,16 @@ RSpec.describe IAPValidator::IAPValidator do
 
   it 'should validate with error' do
     receipt_data = 'randomreceiptdata'
-    expected_response = { "cool" => 123 }
+    expected_response = { 'cool' => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
-        with(body: { 'receipt-data' => receipt_data }).
-        and_return(status: 400, body: expected_response_str)
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt')
+           .with(body: { 'receipt-data' => receipt_data })
+           .and_return(status: 400, body: expected_response_str)
 
     resp = IAPValidator::IAPValidator.validate(receipt_data, true)
 
     expect(stub).to have_been_requested
     expect(resp).to be_nil
   end
-
 end

--- a/spec/iap-validator_spec.rb
+++ b/spec/iap-validator_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe IAPValidator::IAPValidator do
     expected_response = { "cool" => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
         with(body: { 'receipt-data' => receipt_data }).
         and_return(status: 200, body: expected_response_str)
 
     resp = IAPValidator::IAPValidator.validate(receipt_data, true)
+
+    expect(stub).to have_been_requested
     expect(resp).to eq(expected_response)
   end
 
@@ -20,7 +22,7 @@ RSpec.describe IAPValidator::IAPValidator do
     expected_response = { "cool" => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
         with(body: { 'receipt-data' => receipt_data }).
         and_return(status: 400, body: expected_response_str)
 
@@ -29,6 +31,7 @@ RSpec.describe IAPValidator::IAPValidator do
       error = error_resp
     end
 
+    expect(stub).to have_been_requested
     expect(resp).to be_nil
     expect(error).to_not be_nil
     expect(error.code).to eq(400)
@@ -40,13 +43,14 @@ RSpec.describe IAPValidator::IAPValidator do
     expected_response = { "cool" => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
         with(body: { 'receipt-data' => receipt_data }).
         and_return(status: 400, body: expected_response_str)
 
     error = nil
     resp = IAPValidator::IAPValidator.validate(receipt_data, true)
 
+    expect(stub).to have_been_requested
     expect(resp).to be_nil
     expect(error).to be_nil
   end

--- a/spec/iap-validator_spec.rb
+++ b/spec/iap-validator_spec.rb
@@ -1,0 +1,38 @@
+require 'helper'
+
+RSpec.describe IAPValidator::IAPValidator do
+
+  it 'should validate' do
+    receipt_data = 'randomreceiptdata'
+    expected_response = { "cool" => 123 }
+    expected_response_str = MultiJson.dump(expected_response)
+
+    stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
+        with(body: { 'receipt-data' => receipt_data }).
+        and_return(status: 200, body: expected_response_str)
+
+    resp = IAPValidator::IAPValidator.validate(receipt_data, true)
+    expect(resp).to eq(expected_response)
+  end
+
+  it 'should validate with error callback' do
+    receipt_data = 'randomreceiptdata'
+    expected_response = { "cool" => 123 }
+    expected_response_str = MultiJson.dump(expected_response)
+
+    stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
+        with(body: { 'receipt-data' => receipt_data }).
+        and_return(status: 400, body: expected_response_str)
+
+    error = nil
+    resp = IAPValidator::IAPValidator.validate(receipt_data, true) do |error_resp|
+      error = error_resp
+    end
+
+    expect(resp).to be_nil
+    expect(error).to_not be_nil
+    expect(error.code).to eq(400)
+    expect(error.body).to eq(expected_response_str)
+  end
+
+end

--- a/spec/iap-validator_spec.rb
+++ b/spec/iap-validator_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe IAPValidator::IAPValidator do
     expect(error.body).to eq(expected_response_str)
   end
 
+  it 'should validate without error callback' do
+    receipt_data = 'randomreceiptdata'
+    expected_response = { "cool" => 123 }
+    expected_response_str = MultiJson.dump(expected_response)
+
+    stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
+        with(body: { 'receipt-data' => receipt_data }).
+        and_return(status: 400, body: expected_response_str)
+
+    error = nil
+    resp = IAPValidator::IAPValidator.validate(receipt_data, true)
+
+    expect(resp).to be_nil
+    expect(error).to be_nil
+  end
+
 end

--- a/test/test_iap-validator.rb
+++ b/test/test_iap-validator.rb
@@ -1,4 +1,0 @@
-require 'helper'
-
-class TestIapValidator < Test::Unit::TestCase
-end


### PR DESCRIPTION
This transition is because:

1) The old HTTParty implementation was not thread-safe as it involved modifying class variables (potentially) shared across threads
2) We want to standardize on Typhoeus for HTTP requests